### PR TITLE
Wrong coloring Default theme Dark Modern

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "cdata-js-highlighter",
   "displayName": "CDATA JS Highlighter",
   "description": "Syntax Highlighting for embedded JavaScript inside CDATA tags.",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "publisher": "PaulGomez",
   "icon": "images/icon.png",
   "engines": {

--- a/syntaxes/xml.tmLanguage.json
+++ b/syntaxes/xml.tmLanguage.json
@@ -13,36 +13,13 @@
             },
             "patterns": [
                 {
-                    "include": "#javascriptInsideCDATA"
-                }
-            ]
-        },
-        {
-            "include": "#xmlOutsideCDATA"
-        }
-    ],
-    "repository": {
-        "javascriptInsideCDATA": {
-            "begin": "(?<=<!\\[CDATA\\[)[^\\]]*\\n?",
-            "beginCaptures": {
-                "0": { "name": "source.js.embedded.xml" }
-            },
-            "end": "(?=\\]\\]>)",
-            "patterns": [
-                {
                     "include": "source.js"
                 }
             ]
         },
-        "xmlOutsideCDATA": {
-            "begin": "(?<=^|>)(?!(<!\\[CDATA\\[))",
-            "end": "(?=(<!\\[CDATA\\[|]]>))",
-            "patterns": [
-                {
-                    "include": "text.html.basic"
-                }
-            ]
+        {
+            "include": "text.xml"
         }
-    },
+    ],
     "scopeName": "source.xml"
 }


### PR DESCRIPTION
When we use the VSCode default theme "Dark Modern", the coloring of the XML is all wrong.

For instance, the following XML :
![normal](https://github.com/user-attachments/assets/2cf5205b-e556-4fe1-9883-de264caffa80)
Would be translated as follow :
![original](https://github.com/user-attachments/assets/2984dcef-17a7-4193-8495-eb01cdfeda05)

This pull request would bring the coloring to the following :
![patch](https://github.com/user-attachments/assets/40057242-c012-4370-9630-2afb7fc80f96)
